### PR TITLE
fix: add closing modal when submit and get empty data if user has no …

### DIFF
--- a/src/app/setting/team/CreateTeamModal.tsx
+++ b/src/app/setting/team/CreateTeamModal.tsx
@@ -59,6 +59,7 @@ export function CreateTeamModal() {
 									});
 
 									mutate();
+									setOpenModal(false);
 								} catch (e: any) {
 									toast({
 										title: "팀 생성 실패",

--- a/src/app/setting/team/team-form.tsx
+++ b/src/app/setting/team/team-form.tsx
@@ -347,7 +347,7 @@ export function TeamForm() {
 					팀 탈퇴
 				</Button>
 			</div>
-			{teamInfo && <LeaderTeamExitModal isOpen={leaderExitModalOpen} setIsOpen={setLeaderExitModalOpen} teamInfo={teamInfo} />}
+			{teamInfo && <LeaderTeamExitModal isOpen={leaderExitModalOpen} setIsOpen={setLeaderExitModalOpen} teamInfo={teamInfo} teamMutate={teamMutate} />}
 		</>
 	);
 }

--- a/src/components/global/RemoveModal.tsx
+++ b/src/components/global/RemoveModal.tsx
@@ -8,6 +8,7 @@ import { useRouter } from "next/navigation";
 import { useToast } from "@/components/ui/use-toast";
 import { Dispatch, SetStateAction } from "react";
 import axios from "axios";
+import { KeyedMutator } from "swr";
 type removeType = "Project" | "Bucket" | "Note";
 const removeTypeDescription = {
 	Project: "프로젝트",
@@ -149,7 +150,7 @@ export default function RemoveModal({
 	);
 }
 import { TeamInfoType } from "@/hooks/fetch/useTeam";
-export function LeaderTeamExitModal({ isOpen, setIsOpen, teamInfo }: { isOpen: boolean; setIsOpen: Dispatch<SetStateAction<boolean>>; teamInfo: TeamInfoType }) {
+export function LeaderTeamExitModal({ isOpen, setIsOpen, teamInfo, teamMutate }: { isOpen: boolean; setIsOpen: Dispatch<SetStateAction<boolean>>; teamInfo: TeamInfoType; teamMutate: KeyedMutator<any> }) {
 	const [confirmEntityName, setConfirmEntityName] = useState<string>("");
 	const { toast } = useToast();
 	return (
@@ -184,6 +185,8 @@ export function LeaderTeamExitModal({ isOpen, setIsOpen, teamInfo }: { isOpen: b
 									title: "삭제 완료",
 									description: `팀 ${teamInfo.name}의 삭제가 완료되었습니다.`,
 								});
+								teamMutate();
+								setIsOpen(false);
 							} catch (e: any) {
 								toast({
 									title: "삭제 실패",

--- a/src/hooks/fetch/useTeam.ts
+++ b/src/hooks/fetch/useTeam.ts
@@ -88,8 +88,15 @@ type InvitationSendType = {
 
 const useTeamMemberList = () => {
 	const { data, error, isLoading, mutate } = useSWRImmutable(process.env.NEXT_PUBLIC_API_URL + "/user/team/list", fetcher);
+	if ( data?.data === null ) {
+		return {
+			memberList: [],
+			isLoading,
+			error,
+			mutate,
+		};	
+	}
 	console.log(data?.data.map((member: any) => member.id));
-
 	const memberList: TeamMemberType[] = data?.data.map((member: any) => {
 		const eachMember = {
 			id: member.id,


### PR DESCRIPTION
1. 설정/팀 에서 유저가 팀이 없을 시 빈 데이터를 받을 수 있도록 수정하였습니다.
2. 팀 삭제 or 탈퇴시 swr mutate 안되는 현상과 팀이 없을 시 페이지가 깜빡이는 현상 해결되었습니다.